### PR TITLE
memory problems fixed by sorting before coverage check

### DIFF
--- a/mimseq/splitClusters.py
+++ b/mimseq/splitClusters.py
@@ -247,11 +247,15 @@ def covCheck_mp(bedTool, unique_isodecoderMMs, covDiff, input):
     unsplit_isosOnly = set()
     log.info("Calculating nucleotide coverage for {}".format(input))
     bam = pybedtools.BedTool(input)
+    # generate a temporary 2 column file with the chromosome names in the bam file
     temp_chrom = input + "_chrom.txt"
     cmd = "samtools view -H " + input + " | grep @SQ|sed 's/@SQ\tSN:\|LN://g' > " + temp_chrom
     subprocess.call(cmd, shell = True)
+    # sort the bedfile to match the bam ordering
     bedTool = bedTool.sort(faidx=temp_chrom)
+    # the sorted options enables a low-memory algorithm for calculating coverage
     cov = bedTool.coverage(bam, s = True, d = True, sorted = True, g = temp_chrom)
+    # remove the temporary chromosome file
     cmd = "rm " + temp_chrom
     subprocess.call(cmd, shell = True)
     cov_df = cov.to_dataframe()


### PR DESCRIPTION
This is a wonderful tool, thank you so much for building it! The idea of using clustering was very clever.
I was getting an intermittent error during the "Determining un-deconvoluted clusters due to insufficient coverage at mismatches" phase. I identified the problem as an out-of-memory issue in the splitClusters code when computing coverage for large bam files. The bedtools coverage documentation recommends sorting large bed files prior to computing coverage (https://bedtools.readthedocs.io/en/latest/content/tools/coverage.html)
```
If you are trying to compute coverage for very large files and are having trouble with excessive memory usage, please presort your data by chromosome and then by start position (e.g., sort -k1,1 -k2,2n in.bed > in.sorted.bed for BED files) and then use the -sorted option. This invokes a memory-efficient algorithm designed for large files.
```
To implement this, I extract the chromosomes from the bam file, save that as a temporary 2 column chromosome file, then sort the bed file.
This seems to have fixed my memory problems without breaking anything else.
Best,
Jared Bard