### PR TITLE
fix: open modomics file in read-only mode

### DIFF
--- a/mimseq/tRNAtools.py
+++ b/mimseq/tRNAtools.py
@@ -225,18 +225,21 @@ def getModomics(local_mod):
 			log.info("Modomics retrieved...")
 		except HTTPError as http_err:
 			log.error("Unable to connect to Modomics database! HTTP error: {}. Check status of Modomics webpage. Using local Modomics files...".format(http_err))
-			modomics_path = os.path.dirname(os.path.realpath(__file__)) + '/data/modomics'
-			modomics = open(modomics_path, "r+", encoding = "utf-8")
+			modomics = openLocalModomics()
 		except Exception as err:
 			log.error("Error in connecting to Modomics: {}. Using local Modomics files...".format(err))
-			modomics_path = os.path.dirname(os.path.realpath(__file__)) + '/data/modomics'
-			modomics = open(modomics_path, "r+", encoding = "utf-8")
+			modomics = openLocalModomics()
 	else:
 		log.warning("Retrieval of Modomics database disabled. Using local files instead...")
-		modomics_path = os.path.dirname(os.path.realpath(__file__)) + '/data/modomics'
-		modomics = open(modomics_path, "r+", encoding = "utf-8")
+		modomics = openLocalModomics()
 
 	return modomics, fetch
+
+def openLocalModomics():
+	# Open the local modomics file for reading
+	modomics_path = os.path.dirname(os.path.realpath(__file__)) + '/data/modomics'
+	modomics = open(modomics_path, "r", encoding = "utf-8")
+	return modomics
 
 def modsToSNPIndex(gtRNAdb, tRNAscan_out, mitotRNAs, plastidtRNAs, modifications_table, experiment_name, out_dir, double_cca, threads, snp_tolerance = False, cluster = False, cluster_id = 0.95, posttrans_mod_off = False, pretrnas = False, local_mod = False, search='usearch'):
 # Builds SNP index needed for GSNAP based on modificaiton data for each tRNA and clusters tRNAs


### PR DESCRIPTION
The existing code opens the local modomics file in `r+` (read and write) mode, which fails in singularity/docker containers that aren't writeable (the preferred case). Since the file is only read and not written, there's no reason to open it in writeable mode.

This is related to #45 

Thanks for maintaining this project, @drewjbeh. Not sure if you have any guidelines for contributors to abide by, so let me know if there's anything you'd like me to do.