### PR TITLE
fix: require requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(name='mimseq',
 		"seaborn",
 		"matplotlib",
 		"pybedtools",
+        "requests",
 		"statsmodels"],
 	classifiers=[
 		"Development Status :: 4 - Beta",


### PR DESCRIPTION
The requests package is not part of the Python standard library, but is required by the tRNAtools module